### PR TITLE
feature(core): open the dev panel from the browser console

### DIFF
--- a/.changeset/console-trigger.md
+++ b/.changeset/console-trigger.md
@@ -1,0 +1,5 @@
+---
+"@berenjena/react-dev-panel": minor
+---
+
+Add a browser-console API for the panel. When the panel is in use, `window.devPanel` exposes `open()`, `close()` and `toggle()`, so developers can drive the panel from the console in addition to the keyboard hotkey. It's registered alongside the panel lifecycle (SSR-safe, not present when the panel is disabled) and a one-line discovery hint is logged on mount. The `DevPanelConsoleApi` type is exported for typing `window.devPanel`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ useDevPanel("Settings", controls, {
 });
 ```
 
+### Open from the console
+
+Once the panel is in use, a `devPanel` helper is available on `window` so you can drive it
+straight from the browser console — handy when the hotkey clashes with another shortcut:
+
+```js
+devPanel.open(); // show the panel
+devPanel.close(); // hide it
+devPanel.toggle(); // flip visibility (same as the hotkey)
+```
+
+It's registered automatically when the first (enabled) `useDevPanel` call mounts, so it isn't
+present in builds where the panel is disabled.
+
 ### Panel Theme
 
 ```tsx

--- a/src/hooks/useDevPanel/consoleApi.spec.ts
+++ b/src/hooks/useDevPanel/consoleApi.spec.ts
@@ -1,0 +1,62 @@
+import { vi } from "vitest";
+
+import { hideDevPanel, showDevPanel, toggleDevPanel } from "@/store/UIStore";
+
+import { registerDevPanelConsoleApi, unregisterDevPanelConsoleApi } from "./consoleApi";
+
+const STORAGE_KEY = "dev-panel-ui-storage";
+
+/** Reads the persisted `isVisible` flag written by UIStore. */
+function readVisible(): boolean {
+	return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}").isVisible;
+}
+
+describe("devPanel console API", () => {
+	afterEach(() => {
+		unregisterDevPanelConsoleApi();
+		vi.restoreAllMocks();
+	});
+
+	it("registers window.devPanel wired to the store visibility actions", () => {
+		vi.spyOn(console, "info").mockImplementation(() => {});
+
+		registerDevPanelConsoleApi();
+
+		expect(window.devPanel).toBeDefined();
+		expect(window.devPanel?.open).toBe(showDevPanel);
+		expect(window.devPanel?.close).toBe(hideDevPanel);
+		expect(window.devPanel?.toggle).toBe(toggleDevPanel);
+	});
+
+	it("logs the discovery hint once on register", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+		registerDevPanelConsoleApi();
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info.mock.calls[0][0]).toContain("devPanel.toggle()");
+	});
+
+	it("removes window.devPanel on unregister", () => {
+		vi.spyOn(console, "info").mockImplementation(() => {});
+
+		registerDevPanelConsoleApi();
+		unregisterDevPanelConsoleApi();
+
+		expect(window.devPanel).toBeUndefined();
+	});
+
+	it("open/close/toggle flip the panel visibility", () => {
+		showDevPanel();
+		expect(readVisible()).toBe(true);
+
+		hideDevPanel();
+		expect(readVisible()).toBe(false);
+
+		toggleDevPanel();
+		expect(readVisible()).toBe(true);
+
+		toggleDevPanel();
+		expect(readVisible()).toBe(false);
+	});
+});

--- a/src/hooks/useDevPanel/consoleApi.ts
+++ b/src/hooks/useDevPanel/consoleApi.ts
@@ -1,0 +1,58 @@
+import { hideDevPanel, showDevPanel, toggleDevPanel } from "@/store/UIStore";
+
+/**
+ * Imperative API exposed on `window.devPanel` so developers can drive the panel
+ * from the browser console, in addition to the keyboard hotkey.
+ *
+ * @example
+ * ```js
+ * devPanel.open();    // show the panel
+ * devPanel.close();   // hide it
+ * devPanel.toggle();  // flip visibility (same as the hotkey)
+ * ```
+ */
+export interface DevPanelConsoleApi {
+	/** Shows the panel (no-op visually if no sections are registered yet). */
+	open: () => void;
+	/** Hides the panel. */
+	close: () => void;
+	/** Toggles visibility — mirrors the keyboard hotkey. */
+	toggle: () => void;
+}
+
+declare global {
+	interface Window {
+		devPanel?: DevPanelConsoleApi;
+	}
+}
+
+/**
+ * Registers `window.devPanel` and prints a one-line discovery hint.
+ *
+ * SSR-safe (no-op when `window` is undefined) and idempotent in practice: it is
+ * called from `mountDevPanelPortal`, which only runs once, so the hint logs a
+ * single time.
+ */
+export function registerDevPanelConsoleApi(): void {
+	if (typeof window === "undefined") return;
+
+	window.devPanel = {
+		open: showDevPanel,
+		close: hideDevPanel,
+		toggle: toggleDevPanel,
+	};
+
+	// Discovery hint. Intentionally does not name the hotkey, which is
+	// configurable per consumer via `hotKeyConfig`.
+	console.info("[DevPanel] ready — type `devPanel.toggle()` in the console to open it.");
+}
+
+/**
+ * Removes `window.devPanel`. Mirrors `unmountDevPanelPortal` for clean teardown
+ * (HMR, tests).
+ */
+export function unregisterDevPanelConsoleApi(): void {
+	if (typeof window === "undefined") return;
+
+	delete window.devPanel;
+}

--- a/src/hooks/useDevPanel/mountDevPanelPortal.ts
+++ b/src/hooks/useDevPanel/mountDevPanelPortal.ts
@@ -3,6 +3,8 @@ import { createRoot, type Root } from "react-dom/client";
 
 import { DevPanelPortal } from "@/components/DevPanelPortal";
 
+import { registerDevPanelConsoleApi, unregisterDevPanelConsoleApi } from "./consoleApi";
+
 const CONTAINER_ID = "dev-panel-portal-container";
 
 let root: Root | null = null;
@@ -44,6 +46,9 @@ export function mountDevPanelPortal(): void {
 
 	root = createRoot(container);
 	root.render(createElement(DevPanelPortal));
+
+	// Expose the console API (window.devPanel) alongside the panel lifecycle.
+	registerDevPanelConsoleApi();
 }
 
 /**
@@ -57,4 +62,6 @@ export function unmountDevPanelPortal(): void {
 
 	container?.remove();
 	container = null;
+
+	unregisterDevPanelConsoleApi();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { useDevPanel } from "@/hooks/useDevPanel";
+export type { DevPanelConsoleApi } from "@/hooks/useDevPanel/consoleApi";
 export type { DevPanelProps } from "@/components/DevPanel/types";
 export type { ControlsGroup } from "@/components/ControlRenderer/controls/types";

--- a/src/store/UIStore.ts
+++ b/src/store/UIStore.ts
@@ -178,6 +178,29 @@ class DevPanelUIService extends BaseStoreService<DevPanelUIState, PersistedUISta
 const devPanelUIService = new DevPanelUIService();
 
 /**
+ * Imperatively shows the dev panel. Usable outside React (e.g. the console API).
+ * The panel still only appears on screen if at least one section is registered.
+ */
+export function showDevPanel(): void {
+	devPanelUIService.setVisible(true);
+}
+
+/**
+ * Imperatively hides the dev panel. Usable outside React (e.g. the console API).
+ */
+export function hideDevPanel(): void {
+	devPanelUIService.setVisible(false);
+}
+
+/**
+ * Imperatively toggles the dev panel visibility — mirrors the keyboard hotkey.
+ * Usable outside React (e.g. the console API).
+ */
+export function toggleDevPanel(): void {
+	devPanelUIService.setVisible(!devPanelUIService.getSnapshot().isVisible);
+}
+
+/**
  * React hook that provides access to the complete dev panel UI state and actions.
  * Uses useSyncExternalStore for optimal performance and React 18 compatibility.
  * This hook will not re-render when sections state changes.


### PR DESCRIPTION
## 📋 Description

### What does this PR do?

Adds a browser-console API for the dev panel. When the panel is in use, a
`window.devPanel` helper exposes `open()`, `close()` and `toggle()`, so
developers can drive the panel from the console in addition to the keyboard
hotkey — useful when the hotkey clashes with another shortcut. Requested by a
consumer. Non-breaking and additive.

**How it works:**

- New imperative visibility actions in `UIStore` (`showDevPanel` / `hideDevPanel`
  / `toggleDevPanel`) that delegate to the existing singleton.
- A new `consoleApi` module registers `window.devPanel`, augments the `Window`
  type, and logs a one-line discovery hint on mount.
- Registration/cleanup is wired into `mountDevPanelPortal`, in symmetry with the
  portal lifecycle: it runs once and is removed on teardown/HMR.
- SSR-safe (guarded by `typeof window`) and only present when an **enabled**
  `useDevPanel` call mounts — consistent with the `enabled` flag.
- `DevPanelConsoleApi` type exported from the barrel for typing `window.devPanel`.

```js
devPanel.open();   // show the panel
devPanel.close();  // hide it
devPanel.toggle(); // flip visibility (same as the hotkey)
```

---

## 🎯 Type of change

-   [ ] 🐛 **Bugfix** - Fixes an existing bug
-   [x] ✨ **Feature** - Adds new functionality
-   [ ] 🔧 **Chore** - Maintenance, configuration or dependency changes
-   [x] 📚 **Docs** - Documentation update
-   [ ] 🎨 **Style** - Formatting/style changes (no functional impact)
-   [ ] ♻️ **Refactor** - Code improvement without changing functionality
-   [ ] ⚡ **Performance** - Performance improvements
-   [x] 🧪 **Test** - Adds or improves tests
-   [ ] 💥 **Breaking Change** - Changes that break compatibility

---

## 🏗️ Affected areas

-   [x] 🪝 **Hook / Core** (`src/hooks`, `src/managers`) - `useDevPanel`, auto-mount, manager
-   [x] 🗄️ **Stores** (`src/store`) - state, persistence, themes
-   [ ] 🎛️ **Controls** (`src/components/ControlRenderer/controls`) - control types
-   [ ] 🧩 **UI / Components** (`src/components`) - panel, sections, render
-   [ ] 🎨 **Styles / Theming** (`src/styles`) - tokens, mixins, themes
-   [ ] 📦 **Build / Packaging** (`vite.config.ts`, `package.json`, `exports`) - bundle, types, release
-   [x] 🧪 **Tests** (`*.spec.ts`)
-   [x] 📚 **Docs** (`README.md`, `guides/`)

---

## 🔗 Related links

### Issues

-   Related: #ISSUE_NUMBER <!-- replace or remove if not applicable -->

### Release

-   [x] Includes a **Changeset** (`npm run changeset`) for consumer-facing changes

---

## ⚠️ Notes for reviewers

### Key points to review

- **Lifecycle**: `window.devPanel` is registered from `mountDevPanelPortal` (runs
  once) and removed in `unmountDevPanelPortal`. It's only present when an enabled
  `useDevPanel` call mounts, so it's absent in builds where the panel is disabled.
- **Discovery hint**: a single `console.info` on mount. It intentionally does not
  name the hotkey, since that's configurable per consumer via `hotKeyConfig`.
- **`open()` with no sections**: sets `isVisible = true` but nothing shows until a
  section is registered — same behaviour as the hotkey today.

### Changes requiring special attention

- `UIStore` now exports imperative `showDevPanel` / `hideDevPanel` /
  `toggleDevPanel` actions (used by the console API; also usable directly).

### Additional setup required

- None.

---

**Verification:** `npm run build` ✅ · `npm run lint` ✅ · `npm run test` ✅ (150)
· `npm run size` ✅ · Storybook smoke (console `open`/`close`/`toggle` + hint) ✅
