### PR TITLE
feature(ui): searchable option for the multiselect control

### DIFF
--- a/.changeset/multiselect-searchable.md
+++ b/.changeset/multiselect-searchable.md
@@ -1,0 +1,5 @@
+---
+"@berenjena/react-dev-panel": minor
+---
+
+Add `searchable` (and `searchPlaceholder`) support to the `multiselect` control, mirroring the `select` control. When `searchable: true`, a filter box appears above the options and narrows the list by label (case-insensitive) while keeping multiple selection. The underlying shared `Select` already supported this in multi mode; the control now exposes the props.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,11 +42,13 @@
 ### Issues
 
 <!-- Reference the GitHub issue this PR resolves or relates to -->
+
 -   Related: #ISSUE_NUMBER
 
 ### Release
 
 <!-- Check if applicable -->
+
 -   [ ] Includes a **Changeset** (`npm run changeset`) for consumer-facing changes
 
 ---

--- a/guides/controls/MULTISELECT_CONTROL.md
+++ b/guides/controls/MULTISELECT_CONTROL.md
@@ -16,17 +16,46 @@ Dropdown interface for selecting multiple options with checkbox-based selection.
 
 ## Properties
 
-| Property   | Type                         | Default     | Description               |
-| ---------- | ---------------------------- | ----------- | ------------------------- |
-| `type`     | `'multiselect'`              | —           | Control type              |
-| `value`    | `string[]`                   | —           | Selected values           |
-| `options`  | `string[] \| SelectOption[]` | —           | Available options         |
-| `onChange` | `(value: string[]) => void`  | —           | Change handler            |
-| `label`    | `string`                     | `undefined` | Display label             |
-| `disabled` | `boolean`                    | `false`     | Disabled state            |
-| `persist`  | `boolean`                    | `false`     | Auto-save to localStorage |
+| Property            | Type                         | Default       | Description                            |
+| ------------------- | ---------------------------- | ------------- | -------------------------------------- |
+| `type`              | `'multiselect'`              | —             | Control type                           |
+| `value`             | `string[]`                   | —             | Selected values                        |
+| `options`           | `string[] \| SelectOption[]` | —             | Available options                      |
+| `onChange`          | `(value: string[]) => void`  | —             | Change handler                         |
+| `searchable`        | `boolean`                    | `false`       | Show a search box that filters options |
+| `searchPlaceholder` | `string`                     | `'Search...'` | Placeholder for the search box         |
+| `label`             | `string`                     | `undefined`   | Display label                          |
+| `disabled`          | `boolean`                    | `false`       | Disabled state                         |
+| `persist`           | `boolean`                    | `false`       | Auto-save to localStorage              |
 
 ## Examples
+
+### Searchable (long lists)
+
+Set `searchable: true` to add a filter box above the options — useful when the list is long.
+The search matches option labels (case-insensitive); multiple selection works as usual.
+
+```tsx
+const [countries, setCountries] = useState<string[]>(["ar"]);
+
+useDevPanel("Filters", {
+	countries: {
+		type: "multiselect",
+		value: countries,
+		label: "Countries",
+		searchable: true,
+		searchPlaceholder: "Search countries...",
+		options: [
+			{ label: "Argentina", value: "ar" },
+			{ label: "Brazil", value: "br" },
+			{ label: "Chile", value: "cl" },
+			{ label: "Uruguay", value: "uy" },
+			// ...many more
+		],
+		onChange: setCountries,
+	},
+});
+```
 
 ### Feature Flags
 

--- a/guides/controls/SELECT_CONTROL.md
+++ b/guides/controls/SELECT_CONTROL.md
@@ -16,15 +16,17 @@ Dropdown interface for choosing from predefined options.
 
 ## Properties
 
-| Property   | Type                         | Default     | Description               |
-| ---------- | ---------------------------- | ----------- | ------------------------- |
-| `type`     | `'select'`                   | —           | Control type              |
-| `value`    | `string`                     | —           | Selected value            |
-| `options`  | `string[] \| SelectOption[]` | —           | Available options         |
-| `onChange` | `(value: string) => void`    | —           | Change handler            |
-| `label`    | `string`                     | `undefined` | Display label             |
-| `disabled` | `boolean`                    | `false`     | Disabled state            |
-| `persist`  | `boolean`                    | `false`     | Auto-save to localStorage |
+| Property            | Type                         | Default       | Description                            |
+| ------------------- | ---------------------------- | ------------- | -------------------------------------- |
+| `type`              | `'select'`                   | —             | Control type                           |
+| `value`             | `string`                     | —             | Selected value                         |
+| `options`           | `string[] \| SelectOption[]` | —             | Available options                      |
+| `onChange`          | `(value: string) => void`    | —             | Change handler                         |
+| `searchable`        | `boolean`                    | `false`       | Show a search box that filters options |
+| `searchPlaceholder` | `string`                     | `'Search...'` | Placeholder for the search box         |
+| `label`             | `string`                     | `undefined`   | Display label                          |
+| `disabled`          | `boolean`                    | `false`       | Disabled state                         |
+| `persist`           | `boolean`                    | `false`       | Auto-save to localStorage              |
 
 ## Option Types
 
@@ -41,6 +43,33 @@ options: [
 ```
 
 ## Examples
+
+### Searchable (long lists)
+
+Set `searchable: true` to add a filter box above the options — useful when the list is long.
+The search matches option labels (case-insensitive).
+
+```tsx
+const [country, setCountry] = useState("ar");
+
+useDevPanel("Location", {
+	country: {
+		type: "select",
+		value: country,
+		label: "Country",
+		searchable: true,
+		searchPlaceholder: "Search countries...",
+		options: [
+			{ label: "Argentina", value: "ar" },
+			{ label: "Brazil", value: "br" },
+			{ label: "Chile", value: "cl" },
+			{ label: "Uruguay", value: "uy" },
+			// ...many more
+		],
+		onChange: setCountry,
+	},
+});
+```
 
 ### Theme Selector
 

--- a/src/components/ControlRenderer/controls/MultiSelectControl/MultiSelectControl.stories.tsx
+++ b/src/components/ControlRenderer/controls/MultiSelectControl/MultiSelectControl.stories.tsx
@@ -51,6 +51,7 @@ function MultiSelectControlDemo(): React.ReactNode {
 	const [selectedFruits, setSelectedFruits] = useState<string[]>(["Apple", "Cherry"]);
 	const [selectedColors, setSelectedColors] = useState<string[]>(["red", "blue"]);
 	const [selectedFrameworks, setSelectedFrameworks] = useState<string[]>(["react"]);
+	const [searchableFruits, setSearchableFruits] = useState<string[]>(["Apple"]);
 	const [disabledSelection, setDisabledSelection] = useState<string[]>(["disabled1"]);
 	const [persistentSelection, setPersistentSelection] = useState<string[]>(["react"]);
 
@@ -90,6 +91,17 @@ function MultiSelectControlDemo(): React.ReactNode {
 				onChange: (value) => setSelectedFrameworks(value),
 			},
 
+			searchable: {
+				type: "multiselect",
+				options: fruits,
+				value: searchableFruits,
+				label: "Searchable Fruits",
+				description: "Type in the search box to filter the options",
+				searchable: true,
+				searchPlaceholder: "Search fruits...",
+				onChange: (value) => setSearchableFruits(value),
+			},
+
 			disabled: {
 				type: "multiselect",
 				options: ["disabled1", "disabled2", "disabled3"],
@@ -125,6 +137,7 @@ function MultiSelectControlDemo(): React.ReactNode {
 				selectedFruits,
 				selectedColors,
 				selectedFrameworks,
+				searchableFruits,
 				disabledSelection,
 			}}
 		/>

--- a/src/components/ControlRenderer/controls/MultiSelectControl/index.tsx
+++ b/src/components/ControlRenderer/controls/MultiSelectControl/index.tsx
@@ -12,6 +12,8 @@ import type { MultiSelectControlProps } from "./types";
  * @param props.control.options - Array of available options (strings or objects with label/value)
  * @param props.control.onChange - Callback function triggered when selection changes
  * @param props.control.disabled - Optional flag to disable the control
+ * @param props.control.searchable - Optional flag to show a search input that filters the options
+ * @param props.control.searchPlaceholder - Optional placeholder for the search input
  * @returns JSX element representing the multi-select control
  *
  * @example
@@ -36,6 +38,8 @@ export function MultiSelectControl({ control }: MultiSelectControlProps): React.
 			options={control.options}
 			disabled={control.disabled}
 			placeholder="Select options..."
+			searchable={control.searchable}
+			searchPlaceholder={control.searchPlaceholder}
 			onChange={(value) => control.onChange(value as string[])}
 		/>
 	);

--- a/src/components/ControlRenderer/controls/MultiSelectControl/types.d.ts
+++ b/src/components/ControlRenderer/controls/MultiSelectControl/types.d.ts
@@ -4,6 +4,8 @@ export interface MultiSelectControl extends BaseControl {
 	type: "multiselect";
 	value: string[];
 	options: string[] | { label: string; value: string }[];
+	searchable?: boolean;
+	searchPlaceholder?: string;
 	onChange: (value: string[]) => void;
 }
 


### PR DESCRIPTION
## 📋 Description

### What does this PR do?

Adds a `searchable` option to the **multiselect** control, mirroring the
`select` control. When `searchable: true`, a filter box appears above the
options and narrows the list by label (case-insensitive) while multiple
selection keeps working. Requested by a consumer.

The shared `Select` component already supported search in multi mode, so this
is a pass-through of the existing `searchable` / `searchPlaceholder` props — no
new UI, state, or styles.

```tsx
useDevPanel("Filters", {
	countries: {
		type: "multiselect",
		value: countries,
		searchable: true,
		searchPlaceholder: "Search countries...",
		options: [
			{ label: "Argentina", value: "ar" },
			{ label: "Brazil", value: "br" },
			// ...many more
		],
		onChange: setCountries,
	},
});
```

---

## 🎯 Type of change

-   [ ] 🐛 **Bugfix** - Fixes an existing bug
-   [x] ✨ **Feature** - Adds new functionality
-   [ ] 🔧 **Chore** - Maintenance, configuration or dependency changes
-   [x] 📚 **Docs** - Documentation update
-   [ ] 🎨 **Style** - Formatting/style changes (no functional impact)
-   [ ] ♻️ **Refactor** - Code improvement without changing functionality
-   [ ] ⚡ **Performance** - Performance improvements
-   [ ] 🧪 **Test** - Adds or improves tests
-   [ ] 💥 **Breaking Change** - Changes that break compatibility

---

## 🏗️ Affected areas

-   [ ] 🪝 **Hook / Core** (`src/hooks`, `src/managers`) - `useDevPanel`, auto-mount, manager
-   [ ] 🗄️ **Stores** (`src/store`) - state, persistence, themes
-   [x] 🎛️ **Controls** (`src/components/ControlRenderer/controls`) - control types
-   [ ] 🧩 **UI / Components** (`src/components`) - panel, sections, render
-   [ ] 🎨 **Styles / Theming** (`src/styles`) - tokens, mixins, themes
-   [ ] 📦 **Build / Packaging** (`vite.config.ts`, `package.json`, `exports`) - bundle, types, release
-   [ ] 🧪 **Tests** (`*.spec.ts`)
-   [x] 📚 **Docs** (`README.md`, `guides/`)

---

## 🔗 Related links

### Issues

-   Related: #ISSUE_NUMBER <!-- replace or remove if not applicable -->

### Release

-   [x] Includes a **Changeset** (`npm run changeset`) for consumer-facing changes

---

## ⚠️ Notes for reviewers

### Key points to review

- Pure pass-through: the shared `Select` already filters options in multi mode
  (`filteredOptions` feeds the checkbox render). The control just exposes the
  props that `select` already had.
- Also documents `searchable` in the **Select** guide, which was missing it
  (pre-existing gap).

### Changes requiring special attention

- None — additive, no behaviour change for existing multiselect usage.

### Additional setup required

- None.

---

**Verification:** `npm run build` ✅ · `npm run lint` ✅ · `npm run test` ✅ (150)
· `npm run size` ✅ · Storybook smoke (search box filters, checkboxes still toggle, "No results found") ✅
