### PR TITLE
bugfix(core): prevent infinite render loop for array/object control v…

### DIFF
--- a/.changeset/fix-multiselect-render-loop.md
+++ b/.changeset/fix-multiselect-render-loop.md
@@ -1,0 +1,5 @@
+---
+"@berenjena/react-dev-panel": patch
+---
+
+Fix an infinite render loop ("Maximum update depth exceeded") for controls whose `value` is an array or object, such as `multiselect`. `hasControlsChanged` now compares control values structurally instead of by reference, so a section is no longer re-registered on every render when the consumer rebuilds the value array. Multiselect `options` are now compared as well.

--- a/src/utils/hasControlChanged/hasControlChanged.spec.ts
+++ b/src/utils/hasControlChanged/hasControlChanged.spec.ts
@@ -599,6 +599,89 @@ describe("hasControlsChanged", () => {
 		});
 	});
 
+	describe("multiselect control specific properties", () => {
+		it("should return false when value arrays are equal but reference differs", () => {
+			// Given - simulates a consumer rebuilding the value array on every render
+			const current: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a", "b"],
+					options: ["a", "b", "c"],
+					onChange: vi.fn(),
+				},
+			};
+
+			const previous: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a", "b"],
+					options: ["a", "b", "c"],
+					onChange: vi.fn(),
+				},
+			};
+
+			// When
+			const result = hasControlsChanged(current, previous);
+
+			// Then
+			expect(result).toBe(false);
+		});
+
+		it("should return true when value array contents differ", () => {
+			// Given
+			const current: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a", "b", "c"],
+					options: ["a", "b", "c"],
+					onChange: vi.fn(),
+				},
+			};
+
+			const previous: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a", "b"],
+					options: ["a", "b", "c"],
+					onChange: vi.fn(),
+				},
+			};
+
+			// When
+			const result = hasControlsChanged(current, previous);
+
+			// Then
+			expect(result).toBe(true);
+		});
+
+		it("should return true when options differ", () => {
+			// Given
+			const current: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a"],
+					options: ["a", "b", "c"],
+					onChange: vi.fn(),
+				},
+			};
+
+			const previous: ControlsGroup = {
+				flags: {
+					type: "multiselect",
+					value: ["a"],
+					options: ["a", "b"],
+					onChange: vi.fn(),
+				},
+			};
+
+			// When
+			const result = hasControlsChanged(current, previous);
+
+			// Then
+			expect(result).toBe(true);
+		});
+	});
+
 	describe("text control specific properties", () => {
 		it("should return true when placeholder changes", () => {
 			// Given

--- a/src/utils/hasControlChanged/hasControlChanged.ts
+++ b/src/utils/hasControlChanged/hasControlChanged.ts
@@ -27,9 +27,11 @@ export function hasControlsChanged(current: ControlsGroup, previous?: ControlsGr
 			return true;
 		}
 
-		// Compare value only if both controls have it
+		// Compare value only if both controls have it. Use a structural compare so
+		// controls with array/object values (e.g. multiselect) are not reported as
+		// changed on every render just because the consumer rebuilds the reference.
 		if ("value" in currentControl && "value" in previousControl) {
-			if (currentControl.value !== previousControl.value) {
+			if (!deepEqual(currentControl.value, previousControl.value)) {
 				return true;
 			}
 		}
@@ -62,6 +64,12 @@ export function hasControlsChanged(current: ControlsGroup, previous?: ControlsGr
 		}
 
 		if (currentControl.type === "select" && previousControl.type === "select") {
+			if (!deepEqual(currentControl.options, previousControl.options)) {
+				return true;
+			}
+		}
+
+		if (currentControl.type === "multiselect" && previousControl.type === "multiselect") {
 			if (!deepEqual(currentControl.options, previousControl.options)) {
 				return true;
 			}


### PR DESCRIPTION
## 📋 Description

### What does this PR do?

Fixes an infinite render loop (`Maximum update depth exceeded`) that appeared in **v2.5** for any control whose `value` is an array or object — in practice, the `multiselect` control.

**Root cause (two pieces):**

1. `hasControlsChanged` compared a control's `value` by reference (`!==`). A control with an array/object `value` (like `multiselect`, whose value consumers typically rebuild each render via `.map(...)`) was reported as changed on **every render**, so `registerSection` fired every render.
2. v2.5 swapped the store's `setState` comparison from `JSON.stringify` to `deepEqual` (commit `b5f762b`). `deepEqual` compares functions by reference, and the hook re-wraps `onChange` of `persist` controls into new functions on every render — so each redundant re-registration became a **real** store mutation. Since the registration effect depends on `sections`, the store update re-triggered the effect → infinite loop.

Before v2.5 this never closed the loop because `JSON.stringify` dropped functions and compared array *content*, making redundant re-registrations no-ops.

**Fix:** compare control `value` structurally with `deepEqual` (already imported), and deep-compare `multiselect` `options` as well. Adds regression tests and a `patch` changeset.

---

## 🎯 Type of change

-   [x] 🐛 **Bugfix** - Fixes an existing bug

---

## 🏗️ Affected areas

-   [x] 🪝 **Hook / Core** (`src/hooks`, `src/managers`) - `useDevPanel`, auto-mount, manager
-   [x] 🧪 **Tests** (`*.spec.ts`)

---

## 🔗 Related links 

### Release

-   [x] Includes a **Changeset** (`npm run changeset`) for consumer-facing changes

---

## ⚠️ Notes for reviewers

### Key points to review

- The single behavioral change is in `hasControlsChanged`: value comparison moved from `!==` to `deepEqual`. This is also more correct generally — `multiselect` `options` previously had **no** comparison branch, so option changes went undetected.
- Among current control types, `multiselect` is the only one with an array/object `value`; all others (`boolean`, `string`, `number`) are primitives. The fix is generic, so future controls with array/object values are covered automatically.

### Changes requiring special attention

- The deeper interaction with `BaseStoreService.setState`'s `deepEqual` (which detects handler-only changes) is left as-is; this PR breaks the loop at the `hasControlsChanged` layer. No change to store semantics.

### Additional setup required

- None.
